### PR TITLE
TA#83757 [14.0][FIX] delivery_custom_notification : multiple fixes

### DIFF
--- a/delivery_custom_notification/README.rst
+++ b/delivery_custom_notification/README.rst
@@ -6,8 +6,8 @@ It provides fine-grained control over delivery notifications at the carrier leve
 
 Features
 --------
-* **Contact Typing**: Tag contacts as "Delivery Contacts" using a dedicated boolean field
-* **Filtered Selection**: Only tagged delivery contacts appear in the selection dropdown
+* **Contact Typing**: Use native Odoo contact types with new "Delivery Contact" option
+* **Filtered Selection**: Only contacts with type "Delivery Contact" appear in the selection dropdown
 * **Easy Search**: Filter and find all delivery contacts via the search view
 * **Carrier-Level Configuration**: Enable/disable custom notifications and configure email templates per delivery carrier
 * **Intelligent Recipient Selection**: Automatically sends to delivery contact if configured, otherwise falls back to main partner
@@ -19,24 +19,25 @@ Features
 Configuration
 -------------
 
-Step 1: Tag Delivery Contacts
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-1. Navigate to **Contacts** and open a contact record (not a company)
-2. Go to the **Sales & Purchase** tab
-3. In the **Sale** section, check the **Is Delivery Contact** checkbox
-4. This tags the contact as eligible for receiving delivery notifications
+Step 1: Create Delivery Contact
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+1. Navigate to **Contacts** and open a partner/company form
+2. Create a new contact (or open an existing child contact)
+3. In the contact form, set the **Type** field to **"Delivery Contact"**
+4. Fill in the contact's email address
+5. Save the contact
 
-**Note**: The "Is Delivery Contact" checkbox is only visible on contact records, not on company records.
+**Note**: The "Delivery Contact" type appears in the standard Odoo Type field (same as Invoice Address, Delivery Address, etc.).
 
 Step 2: Assign Delivery Contact to Partner
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1. Navigate to **Contacts** and open a partner/company form
 2. Go to the **Sales & Purchase** tab
 3. In the **Misc** section, set the **Delivery Contact** field
-4. The dropdown will only show child contacts that have been tagged as "Delivery Contacts"
-5. You can create a new delivery contact on-the-fly, and it will be automatically tagged
+4. The dropdown will only show child contacts with type "Delivery Contact"
+5. You can create a new delivery contact on-the-fly by clicking "Create and Edit"
 
-**Tip**: Use the search filter "Delivery Contacts" to quickly find all tagged contacts in your system.
+**Tip**: Use the search filter "Delivery Contacts" to quickly find all contacts of this type in your system.
 
 Step 3: Configure Email Template
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -106,7 +107,7 @@ Technical Details
 
 Models Extended
 ~~~~~~~~~~~~~~~
-* **res.partner**: Adds ``is_delivery_contact`` and ``delivery_contact_id`` fields
+* **res.partner**: Extends ``type`` selection with new "Delivery Contact" option and adds ``delivery_contact_id`` field
 * **delivery.carrier**: Adds ``send_delivery_notification`` and ``delivery_notification_template_id`` fields
 * **stock.picking**: Overrides ``_send_confirmation_email()`` method
 

--- a/delivery_custom_notification/i18n/fr.po
+++ b/delivery_custom_notification/i18n/fr.po
@@ -1,0 +1,100 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# * delivery_custom_notification
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 14.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-15 21:00:00+0000\n"
+"PO-Revision-Date: 2026-06-15 21:00:00+0000\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: delivery_custom_notification
+#: model:ir.model.fields,field_description:delivery_custom_notification.field_delivery_carrier__delivery_notification_template_id
+msgid "Delivery Notification Template"
+msgstr "Modèle de notification de livraison"
+
+#. module: delivery_custom_notification
+#: model:ir.model.fields,help:delivery_custom_notification.field_delivery_carrier__delivery_notification_template_id
+msgid "Email template used for delivery notifications. Must be configured for stock.picking model."
+msgstr "Modèle de courriel utilisé pour les notifications de livraison. Doit être configuré pour le modèle stock.picking."
+
+#. module: delivery_custom_notification
+#: model:ir.model.fields,field_description:delivery_custom_notification.field_res_partner__delivery_contact_id
+msgid "Delivery Contact"
+msgstr "Contact de livraison"
+
+#. module: delivery_custom_notification
+#: model:ir.model.fields.selection,name:delivery_custom_notification.selection__res_partner__type__delivery_contact
+msgid "Delivery Contact"
+msgstr "Contact de livraison"
+
+#. module: delivery_custom_notification
+#: model:ir.model.fields,help:delivery_custom_notification.field_res_partner__delivery_contact_id
+msgid "Contact who will receive delivery notifications instead of the main partner. Only contacts with type \"Delivery Contact\" are available for selection."
+msgstr "Contact qui recevra les notifications de livraison au lieu du partenaire principal. Seuls les contacts de type \"Contact de livraison\" sont disponibles pour la sélection."
+
+#. module: delivery_custom_notification
+#: model:ir.model.fields,field_description:delivery_custom_notification.field_delivery_carrier__send_delivery_notification
+msgid "Send Delivery Notification"
+msgstr "Envoyer la notification de livraison"
+
+#. module: delivery_custom_notification
+#: model:ir.model.fields,help:delivery_custom_notification.field_delivery_carrier__send_delivery_notification
+msgid "When enabled, a custom notification email will be sent when deliveries using this carrier are validated."
+msgstr "Lorsque activé, un courriel de notification personnalisé sera envoyé lorsque les livraisons utilisant ce transporteur sont validées."
+
+#. module: delivery_custom_notification
+#: model:ir.ui.view,arch_db:delivery_custom_notification.view_delivery_carrier_form_notification
+msgid "Notifications"
+msgstr "Notifications"
+
+#. module: delivery_custom_notification
+#: model:ir.ui.view,arch_db:delivery_custom_notification.view_delivery_carrier_form_notification
+msgid "How it works:"
+msgstr "Comment ça fonctionne :"
+
+#. module: delivery_custom_notification
+#: model:ir.ui.view,arch_db:delivery_custom_notification.view_delivery_carrier_form_notification
+msgid "When enabled, outgoing deliveries using this carrier will trigger a custom notification email"
+msgstr "Lorsque activé, les livraisons sortantes utilisant ce transporteur déclencheront un courriel de notification personnalisé"
+
+#. module: delivery_custom_notification
+#: model:ir.ui.view,arch_db:delivery_custom_notification.view_delivery_carrier_form_notification
+msgid "The email will be sent to the partner's Delivery Contact (if configured), otherwise to the main partner"
+msgstr "Le courriel sera envoyé au contact de livraison du partenaire (si configuré), sinon au partenaire principal"
+
+#. module: delivery_custom_notification
+#: model:ir.ui.view,arch_db:delivery_custom_notification.view_delivery_carrier_form_notification
+msgid "The email template can be configured to use alternative mail servers (e.g., Mailgun)"
+msgstr "Le modèle de courriel peut être configuré pour utiliser des serveurs de messagerie alternatifs (ex: Mailgun)"
+
+#. module: delivery_custom_notification
+#: model:ir.ui.view,arch_db:delivery_custom_notification.view_delivery_carrier_form_notification
+msgid "Only applies to delivery orders (WH/OUT), not other operation types"
+msgstr "S'applique uniquement aux bons de livraison (WH/OUT), pas aux autres types d'opérations"
+
+#. module: delivery_custom_notification
+#: model:ir.ui.view,arch_db:delivery_custom_notification.view_res_partner_filter_delivery_contact
+msgid "Delivery Contacts"
+msgstr "Contacts de livraison"
+
+#. module: delivery_custom_notification
+#: model:ir.model,name:delivery_custom_notification.model_delivery_carrier
+msgid "Shipping Methods"
+msgstr "Méthodes d'expédition"
+
+#. module: delivery_custom_notification
+#: model:ir.model,name:delivery_custom_notification.model_res_partner
+msgid "Contact"
+msgstr "Contact"
+
+#. module: delivery_custom_notification
+#: model:ir.model,name:delivery_custom_notification.model_stock_picking
+msgid "Transfer"
+msgstr "Transfert"

--- a/delivery_custom_notification/models/res_partner.py
+++ b/delivery_custom_notification/models/res_partner.py
@@ -5,21 +5,19 @@ from odoo import fields, models
 
 
 class ResPartner(models.Model):
-    """Extend partner to add delivery contact fields."""
+    """Extend partner to add delivery contact type and field."""
 
     _inherit = 'res.partner'
 
-    is_delivery_contact = fields.Boolean(
-        string='Is Delivery Contact',
-        default=False,
-        help='Check this box to mark this contact as a delivery contact. '
-             'Delivery contacts can be selected to receive delivery notifications.',
+    type = fields.Selection(
+        selection_add=[('delivery_contact', 'Delivery Contact')],
+        ondelete={'delivery_contact': 'set default'},
     )
     delivery_contact_id = fields.Many2one(
         'res.partner',
         string='Delivery Contact',
-        domain="[('parent_id', '=', id), ('is_delivery_contact', '=', True)]",
+        domain="[('parent_id', '=', id), ('type', '=', 'delivery_contact')]",
         help='Contact who will receive delivery notifications instead of the main partner. '
-             'Only contacts with the "Is Delivery Contact" flag checked are available for selection.',
+             'Only contacts with type "Delivery Contact" are available for selection.',
         check_company=True,
     )

--- a/delivery_custom_notification/models/stock_picking.py
+++ b/delivery_custom_notification/models/stock_picking.py
@@ -41,7 +41,10 @@ class StockPicking(models.Model):
                 partner_ids=recipient.ids,
             )
 
-        # Call super for remaining pickings (standard behavior)
-        remaining_pickings = self - custom_notification_pickings
+        # Call super for remaining outgoing pickings (standard behavior)
+        # Only process outgoing deliveries to avoid triggering notifications on PICK/PACK operations
+        remaining_pickings = (self - custom_notification_pickings).filtered(
+            lambda p: p.picking_type_id.code == 'outgoing'
+        )
         if remaining_pickings:
             super(StockPicking, remaining_pickings)._send_confirmation_email()

--- a/delivery_custom_notification/views/res_partner_views.xml
+++ b/delivery_custom_notification/views/res_partner_views.xml
@@ -1,28 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
 
-    <record id="view_partner_form_is_delivery_contact" model="ir.ui.view">
-        <field name="name">res.partner.form.is.delivery.contact</field>
-        <field name="model">res.partner</field>
-        <field name="inherit_id" ref="base.view_partner_form"/>
-        <field name="arch" type="xml">
-            <xpath expr="//group[@name='sale']" position="inside">
-                <field name="is_delivery_contact"
-                       attrs="{'invisible': [('company_type', '=', 'company')]}"/>
-            </xpath>
-        </field>
-    </record>
-
     <record id="view_partner_form_delivery_contact" model="ir.ui.view">
         <field name="name">res.partner.form.delivery.contact</field>
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//page[@name='sales_purchases']//group[@name='misc']" position="inside">
+            <field name="property_delivery_carrier_id" position="after">
                 <field name="delivery_contact_id"
-                       domain="[('parent_id', '=', id), ('is_delivery_contact', '=', True)]"
-                       context="{'default_is_delivery_contact': True, 'default_parent_id': id, 'default_type': 'contact'}"/>
-            </xpath>
+                       domain="[('parent_id', '=', id), ('type', '=', 'delivery_contact')]"
+                       context="{'default_type': 'delivery_contact', 'default_parent_id': id}"/>
+            </field>
         </field>
     </record>
 
@@ -32,9 +20,10 @@
         <field name="inherit_id" ref="base.view_res_partner_filter"/>
         <field name="arch" type="xml">
             <filter name="inactive" position="before">
-                <filter name="is_delivery_contact"
+                <separator/>
+                <filter name="delivery_contact"
                         string="Delivery Contacts"
-                        domain="[('is_delivery_contact', '=', True)]"/>
+                        domain="[('type', '=', 'delivery_contact')]"/>
             </filter>
         </field>
     </record>


### PR DESCRIPTION
## Summary

This PR fixes 4 issues reported after initial deployment of the delivery_custom_notification module.

---

## ✅ Fix 1: Use Native Contact Type System

**Problem**: Custom boolean field `is_delivery_contact` was inconsistent with Odoo's standard contact typing system.

**Solution**: 
- Removed custom `is_delivery_contact` boolean field
- Extended native `type` selection field with new "Delivery Contact" option
- Updated domain: `[('type', '=', 'delivery_contact')]`
- Now appears in the same Type dropdown as "Invoice Address", "Delivery Address", etc.

**Benefits**: 
- Consistent with Odoo UX patterns
- Users already familiar with contact types
- Cleaner data model

---

## ✅ Fix 2: Field Positioning

**Problem**: `delivery_contact_id` field was in the Misc section, far from related delivery fields.

**Solution**: 
- Positioned field directly after `property_delivery_carrier_id` (Delivery Method)
- Changed from xpath to direct field positioning

**Benefits**: 
- Logically grouped with delivery configuration
- Better UX flow

---

## ✅ Fix 3: Filter Positioning

**Problem**: "Delivery Contacts" filter was inside the Customer/Supplier/Invoice section.

**Solution**: 
- Added `<separator/>` before the filter
- Creates a distinct section separate from Customer/Supplier filters

**Benefits**: 
- Clear visual separation
- Proper filter organization

---

## ✅ Fix 4: PICK Operations Triggering Notifications

**Problem**: PICK operations with manually added carriers triggered `super()._send_confirmation_email()`, causing unwanted chatter messages.

**Solution**: 
- Added filter on remaining_pickings: `lambda p: p.picking_type_id.code == 'outgoing'`
- Only WH/OUT deliveries now call super()

**Benefits**: 
- PICK/PACK operations no longer trigger notifications
- Cleaner chatter on internal operations

---

## 🇫🇷 Bonus: French Translations

- Added complete `i18n/fr.po` file
- All module strings translated
- Includes field labels, help texts, and UI messages

---

## Technical Changes

**Modified Files**:
- `models/res_partner.py`: Replaced boolean with Selection extension
- `views/res_partner_views.xml`: Updated field positioning and filter section
- `models/stock_picking.py`: Added filtering for super() call
- `i18n/fr.po`: New French translation file (NEW)
- `README.rst`: Updated documentation

**Stats**: 5 files changed, 132 insertions(+), 41 deletions(-)

---

## 📝 Note on Email Recipients

The module uses `message_post_with_template()` with `partner_ids` parameter.

**Important**: Email templates should have recipient fields empty (To, CC, Partner IDs). The module sets recipients programmatically. If templates have preconfigured recipients, duplicates may occur.

This is documented in README with ⚠️ CRITICAL warnings.