### PR TITLE
TA#77476 [14.0][DOC] stock_serial_single_quant : document security group configuration

### DIFF
--- a/stock_serial_single_quant/README.rst
+++ b/stock_serial_single_quant/README.rst
@@ -55,6 +55,21 @@ If the serial number has a quant, the owner of the stock move line must match th
 
 Configuration
 -------------
+
+Security Group
+~~~~~~~~~~~~~~
+Access to the bypass configuration is controlled by the security group **Bypass Serial Constraints**.
+
+To grant a user access to configure the bypass option:
+
+1. Go to **Settings > Users & Companies > Users**.
+2. Select the user you want to configure.
+3. In the **Inventory** section, enable the **Bypass Serial Constraints** permission.
+
+Only users with this permission can view and modify the bypass settings on warehouses.
+
+Bypass by Warehouse
+~~~~~~~~~~~~~~~~~~~
 To bypass the constraints for a specific warehouse:
 
 1. Go to **Inventory > Configuration > Warehouses**.


### PR DESCRIPTION
## Summary
- Added documentation for the new security group that controls access to the bypass serial constraints configuration
- Reorganized the Configuration section with two subsections: Security Group and Bypass by Warehouse
- Explained how to grant users permission to configure the bypass option

## Test plan
- [ ] Review the updated README.rst for clarity and completeness
- [ ] Verify that the documentation accurately reflects the implemented security group functionality