### PR TITLE
TA#83757 [14.0][IMP] delivery_custom_notification : make delivery contact selection fully dynamic

### DIFF
--- a/delivery_custom_notification/README.rst
+++ b/delivery_custom_notification/README.rst
@@ -6,9 +6,9 @@ It provides fine-grained control over delivery notifications at the carrier leve
 
 Features
 --------
-* **Contact Typing**: Use native Odoo contact types with new "Delivery Contact" option
-* **Filtered Selection**: Only contacts with type "Delivery Contact" appear in the selection dropdown
-* **Easy Search**: Filter and find all delivery contacts via the search view
+* **Dynamic Contact Selection**: Any partner can be selected as a delivery contact - no manual tagging required
+* **Smart Search Filter**: Automatically find all contacts currently used as delivery contacts across your system
+* **Flexible Assignment**: Select child contacts or any other partner as the delivery notification recipient
 * **Carrier-Level Configuration**: Enable/disable custom notifications and configure email templates per delivery carrier
 * **Intelligent Recipient Selection**: Automatically sends to delivery contact if configured, otherwise falls back to main partner
 * **Template Flexibility**: Use custom email templates with support for alternative mail servers (e.g., Mailgun)
@@ -19,27 +19,20 @@ Features
 Configuration
 -------------
 
-Step 1: Create Delivery Contact
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-1. Navigate to **Contacts** and open a partner/company form
-2. Create a new contact (or open an existing child contact)
-3. In the contact form, set the **Type** field to **"Delivery Contact"**
-4. Fill in the contact's email address
-5. Save the contact
-
-**Note**: The "Delivery Contact" type appears in the standard Odoo Type field (same as Invoice Address, Delivery Address, etc.).
-
-Step 2: Assign Delivery Contact to Partner
+Step 1: Assign Delivery Contact to Partner
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1. Navigate to **Contacts** and open a partner/company form
 2. Go to the **Sales & Purchase** tab
 3. In the **Misc** section, set the **Delivery Contact** field
-4. The dropdown will only show child contacts with type "Delivery Contact"
-5. You can create a new delivery contact on-the-fly by clicking "Create and Edit"
+4. The dropdown will show all child contacts of the current partner
+5. You can create a new contact on-the-fly by clicking "Create and Edit"
+6. Ensure the selected contact has a valid email address
 
-**Tip**: Use the search filter "Delivery Contacts" to quickly find all contacts of this type in your system.
+**Important**: Any partner can be selected as a delivery contact. There is no special tagging or type required - simply select the contact who should receive delivery notifications.
 
-Step 3: Configure Email Template
+**Dynamic Search Filter**: Use the "Delivery Contacts" search filter to find all partners currently being used as delivery contacts across your entire system. This filter dynamically shows any contact that is set as a delivery contact for at least one other partner.
+
+Step 2: Configure Email Template
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Before configuring carriers, create your delivery notification email template:
 
@@ -66,13 +59,13 @@ Before configuring carriers, create your delivery notification email template:
 - This ensures emails appear in the delivery order's Chatter (message history)
 - Operations teams can see email sending history directly on the picking
 
-Step 4: Configure Delivery Carrier
+Step 3: Configure Delivery Carrier
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1. Navigate to **Inventory > Configuration > Delivery > Shipping Methods**
 2. Open a delivery carrier form
 3. Go to the new **Notifications** tab
 4. Check **Send Delivery Notification**
-5. Select your **Delivery Notification Template** (created in Step 3)
+5. Select your **Delivery Notification Template** (created in Step 2)
 
 Email Template Example (2Ship Integration)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -107,7 +100,7 @@ Technical Details
 
 Models Extended
 ~~~~~~~~~~~~~~~
-* **res.partner**: Extends ``type`` selection with new "Delivery Contact" option and adds ``delivery_contact_id`` field
+* **res.partner**: Adds ``delivery_contact_id`` Many2one field and ``delivery_contact_for_partner_ids`` One2many reverse relation field
 * **delivery.carrier**: Adds ``send_delivery_notification`` and ``delivery_notification_template_id`` fields
 * **stock.picking**: Overrides ``_send_confirmation_email()`` method
 

--- a/delivery_custom_notification/__manifest__.py
+++ b/delivery_custom_notification/__manifest__.py
@@ -3,13 +3,13 @@
 
 {
     "name": "Delivery Custom Notification",
-    "version": "14.0.1.2.0",
+    "version": "14.0.1.3.0",
     "author": "Numigi",
     "maintainer": "Numigi",
     "website": "https://numigi.com/r/home",
     "license": "LGPL-3",
     "category": "Inventory",
-    "summary": "Send custom delivery notifications to specific contacts",
+    "summary": "Send custom delivery notifications to dynamically selected delivery contacts",
     "depends": [
         "delivery",
         "stock",

--- a/delivery_custom_notification/models/res_partner.py
+++ b/delivery_custom_notification/models/res_partner.py
@@ -5,19 +5,20 @@ from odoo import fields, models
 
 
 class ResPartner(models.Model):
-    """Extend partner to add delivery contact type and field."""
+    """Extend partner to add delivery contact field and reverse relation."""
 
     _inherit = 'res.partner'
 
-    type = fields.Selection(
-        selection_add=[('delivery_contact', 'Delivery Contact')],
-        ondelete={'delivery_contact': 'set default'},
-    )
     delivery_contact_id = fields.Many2one(
         'res.partner',
         string='Delivery Contact',
-        domain="[('parent_id', '=', id), ('type', '=', 'delivery_contact')]",
         help='Contact who will receive delivery notifications instead of the main partner. '
-             'Only contacts with type "Delivery Contact" are available for selection.',
+             'Any partner can be selected as the delivery contact.',
         check_company=True,
+    )
+    delivery_contact_for_partner_ids = fields.One2many(
+        'res.partner',
+        'delivery_contact_id',
+        string='Is Delivery Contact For',
+        help='Partners that use this contact as their delivery contact.',
     )

--- a/delivery_custom_notification/models/stock_picking.py
+++ b/delivery_custom_notification/models/stock_picking.py
@@ -41,10 +41,7 @@ class StockPicking(models.Model):
                 partner_ids=recipient.ids,
             )
 
-        # Call super for remaining outgoing pickings (standard behavior)
-        # Only process outgoing deliveries to avoid triggering notifications on PICK/PACK operations
-        remaining_pickings = (self - custom_notification_pickings).filtered(
-            lambda p: p.picking_type_id.code == 'outgoing'
-        )
+        # Call super for remaining pickings (standard behavior)
+        remaining_pickings = self - custom_notification_pickings
         if remaining_pickings:
             super(StockPicking, remaining_pickings)._send_confirmation_email()

--- a/delivery_custom_notification/views/res_partner_views.xml
+++ b/delivery_custom_notification/views/res_partner_views.xml
@@ -8,8 +8,8 @@
         <field name="arch" type="xml">
             <field name="property_delivery_carrier_id" position="after">
                 <field name="delivery_contact_id"
-                       domain="[('parent_id', '=', id), ('type', '=', 'delivery_contact')]"
-                       context="{'default_type': 'delivery_contact', 'default_parent_id': id}"/>
+                       domain="[('parent_id', '=', id)]"
+                       context="{'default_parent_id': id, 'default_type': 'contact'}"/>
             </field>
         </field>
     </record>
@@ -23,7 +23,7 @@
                 <separator/>
                 <filter name="delivery_contact"
                         string="Delivery Contacts"
-                        domain="[('type', '=', 'delivery_contact')]"/>
+                        domain="[('delivery_contact_for_partner_ids', '!=', False)]"/>
             </filter>
         </field>
     </record>


### PR DESCRIPTION
## Summary

This PR refactors the `delivery_custom_notification` module to remove the manual contact typing system and make delivery contact selection fully dynamic.

**Key Changes:**
- Removed the `type` selection extension for "Delivery Contact" type
- Added `delivery_contact_for_partner_ids` One2many reverse relation field
- Updated form view domain to allow selection of any child contact (no type restriction)
- Updated search filter to dynamically show partners currently used as delivery contacts
- Updated documentation to reflect the new dynamic approach

**Benefits:**
- Simplified user experience - no manual tagging required
- More flexible - any partner can be selected as delivery contact
- Dynamic search filter automatically adapts based on actual usage
- Cleaner data model

## Test Plan

- [ ] Install/upgrade the module successfully
- [ ] Open a partner form and verify the Delivery Contact field shows all child contacts
- [ ] Assign a delivery contact to a partner
- [ ] Use the "Delivery Contacts" search filter and verify it shows the assigned contact
- [ ] Create a delivery order with a carrier configured for custom notifications
- [ ] Validate the delivery and verify the notification is sent to the delivery contact
- [ ] Verify email appears in the picking's chatter